### PR TITLE
Use fopen instead of fopen_s

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -300,12 +300,12 @@ int main(int32_t argc, char** argv)
     bool doCrop = (crop.left + crop.top + crop.right + crop.bottom) > 0;
     bool doResync = resync != 1;
 
-    FILE* input; fopen_s(&input, argv[1], "rb");
+    FILE* input = fopen(argv[1], "rb");
     if(input == NULL){
         printf("Unable to open input file!");
         return -1;
     }
-    FILE* output; fopen_s(&output, argv[2], "wb");
+    FILE* output = fopen(argv[2], "wb");
     if(output == NULL){
         printf("Unable to open output file!");
         fclose(input);


### PR DESCRIPTION
`fopen_s` is not available with the gcc/g++ or clang. When using `fopen` instead, the program can also be compiled on macOS and Linux. The additional safety introduced by `fopen_s` shouldn't be required here anyway, as there's already a check for having enough command-line arguments.