### PR TITLE
Add a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+all: supmover
+
+supmover: main.o
+	g++ -o supmover main.o
+
+main.o: main.cpp
+	g++ -std=c++17 -fexceptions -O2 -Wall -Wextra -c main.cpp -o main.o
+
+clean:
+	rm -f *.o supmover
+
+.PHONY: clean


### PR DESCRIPTION
This adds a `Makefile` for convenience. I've set the C++ standard in the Makefile explicitly as this would otherwise result in an error when building with Apple Clang (which defaults to C++98).