### PR TITLE
Add GitHub Actions workflows for macOS and Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: '*'
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install dependencies
+      run: sudo apt-get install -y make g++
+    - name: Compile
+      run: make
+    - name: Strip binary
+      run: strip supmover
+    - uses: actions/upload-artifact@v3
+      with:
+        name: supmover-linux
+        path: supmover
+
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Compile
+      run: make
+    - name: Strip binary
+      run: strip supmover
+    - uses: actions/upload-artifact@v3
+      with:
+        name: supmover-macos
+        path: supmover


### PR DESCRIPTION
These workflows compile SupMover on macOS and Linux. You'll also get the stripped binaries for download on the overview page of the build (for 90 days if I remember correctly), so you can include them in the GitHub Releases page. Currently, both workflows will run on regular amd64 machines. GitHub doesn't support ARM runners yet.
I don't know how you usually would run the build on Windows, so I didn't include that. (I guess, I'd otherwise come up with a rather janky solution...)