### PR TITLE
Add move functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SupMover - Shift timings and Screen Area of PGS/Sup subtitle
 
 # Usage
-`SupMover (<input.sup> <output.sup>) [delay (ms)] [crop (<left> <top> <right> <bottom>)] [resync (<num>/<den> | multFactor)] [add_zero] [tonemap <perc>] [cut_merge <Cut&Merge option>]`
+`SupMover (<input.sup> <output.sup>) [delay (ms)] [move (<delta x> <delta y>)] [crop (<left> <top> <right> <bottom>)] [resync (<num>/<den> | multFactor)] [add_zero] [tonemap <perc>] [cut_merge <Cut&Merge option>]`
 
 `SupMover (<input.sup> <output.sup> <ms>)` old syntax, kept for backward compatibility
 
@@ -11,10 +11,14 @@ SupMover - Shift timings and Screen Area of PGS/Sup subtitle
   * Apply a milliseconds delay, positive or negative, to all the subpic of the subtitle, it can be fractional as the SUP speficication have a precision of 1/90ms
 * resync
   * Multiply all the timestamp by this factor, this can also be supplied as a fraction
+* move
+  * Shift the windows position of all subpic by the inputed parameters (the image data is left untouched).
+  * Position is clamped to the screen edges so that windows are always fully contained within the screen area.
 * crop
   * Crop the windows area of all subpic by the inputed parameters.
   * This is done losslessly by only shifting the windows position (the image data is left untouched).
   * Crop functionality is not exstensivelly tested when multiple Composition Object or Windows are present or when the windows are is outside the new screen area, a warning is issued if that's the case and i strongly advise to check the resulting subtitle with a video player, also handling of the Object Cropped flag and windows area bigger than the new screen area is not implemented, a warning is issued if needed
+  * If both move and crop are selected, the crop is performed after the move.
 * delay + resync
   * If both modes are selected the delay will be adjusted if it comes before the resync parameter, for example if the program is launched with `delay 1000 resync 1.001` it will be internally adjusted to 1001ms, instead if it's launched with `resync 1.001 delay 1000` it will not
 * add_zero

--- a/main.cpp
+++ b/main.cpp
@@ -943,8 +943,12 @@ int main(int32_t argc, char** argv)
                                     if (object->windowID != window->windowID) continue;
 
                                     if (object->objectCroppedFlag == 0x40) {
+                                        t_timestamp timestamp = PTStoTimestamp(header.pts1);
+                                        std::printf("Object Cropped Flag set at timestamp %lu:%02lu:%02lu.%03lu! Crop fields are not supported yet.\r\n", timestamp.hh, timestamp.mm, timestamp.ss, timestamp.ms);
+                                        /*
                                         object->objCropHorPos += clampedDeltaX;
                                         object->objCropVerPos += clampedDeltaY;
+                                         */
                                     }
                                     object->objectHorPos += clampedDeltaX;
                                     object->objectVerPos += clampedDeltaY;


### PR DESCRIPTION
Added a new `move` mode for shifting the position of all windows and their composition objects by the specified delta amount, clamped to keep the window rect fully contained within the screen rect.
Should work with crop flag enabled as well, but not tested.

Motivation for adding this mode was the issue that e.g. moving subtitles out of the lower letterbox area with the current `crop` mode results in all images having their bottom edge aligned with the bottom edge of the crop rect, which doesn't necessarily keep the relative position of subtitle lines.
This means that baselines of consecutive subtitle lines aren't always aligned (e.g. if one line has a letter with a descender — like lowercase *g* — while the next line doesn't), which negatively effects reading experience.
This new `move` mode avoids this issue by keeping the relative positions of images the same (unless it hits a screen edge).

(I also observed that the current `crop` mode also changes the scaling of the images in most players in addition to the position which is not acceptable in my case)