### PR TITLE
`--trace` option & New parsing with optional output file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SupMover - Shift timings and Screen Area of PGS/Sup subtitle
 
 # Usage
 ```
-Usage:  SupMover [OPTIONS ...] <input.sup> [<output.sup>]
+Usage:  SupMover <input.sup> [<output.sup>] [OPTIONS ...]
 
 OPTIONS:
   --trace

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OPTIONS:
 CUT&MERGE OPTIONS:
   --list <list of sections>
   --format (secut | (vapoursynth | vs) | (avisynth | avs) | remap)
-  --timemode (ms | frame | timestamp)
+  --timemode (ms | frame (<num>/<den> | <fps>) | timestamp)
   --fixmode (cut | (delete | del))
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ SupMover - Shift timings and Screen Area of PGS/Sup subtitle
 
 # Usage
 ```
-Usage:  SupMover <input.sup> <output.sup> [OPTIONS ...]
+Usage:  SupMover [OPTIONS ...] <input.sup> [<output.sup>]
 
 OPTIONS:
+  --trace
   --delay <ms>
   --move <delta x> <delta y>
   --crop <left> <top> <right> <bottom>
@@ -21,10 +22,9 @@ CUT&MERGE OPTIONS:
   --fixmode (cut | (delete | del))
 ```
 
-Old syntax, kept for backward compatibility:
-`SupMover <input.sup> <output.sup> <ms>`
-
 # Options
+* `--trace`
+  * Print contents and structure of input file segments
 * `--delay`
   * Apply a milliseconds delay, positive or negative, to all the subpic of the subtitle, it can be fractional as the SUP speficication have a precision of 1/90ms
 * `--resync`

--- a/main.cpp
+++ b/main.cpp
@@ -1041,7 +1041,8 @@ int main(int32_t argc, char** argv)
                                 std::printf("    + Window\n");
                                 t_window window = wds.windows[i];
                                 std::printf("      + Window ID: %u\n", window.windowID);
-                                std::printf("      + Frame: %u,%u %ux%u\n", window.WindowsHorPos, window.WindowsVerPos, window.WindowsWidth, window.WindowsHeight);
+                                std::printf("      + Position: %u,%u\n", window.WindowsHorPos, window.WindowsVerPos);
+                                std::printf("      + Size: %ux%u\n", window.WindowsWidth, window.WindowsHeight);
                             }
                         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -915,8 +915,8 @@ int main(int32_t argc, char** argv)
                             }
                             if (pcs.paletteUpdFlag == 0x80) {
                                 std::printf("    + Palette update: True\n");
-                                std::printf("    + Palette ID: %u\n", pcs.paletteID);
                             }
+                            std::printf("    + Palette ID: %u\n", pcs.paletteID);
                             for (int i = 0; i < pcs.numCompositionObject; i++) {
                                 std::printf("    + Composition object\n");
                                 t_compositionObject object = pcs.compositionObject[i];

--- a/main.cpp
+++ b/main.cpp
@@ -1032,7 +1032,7 @@ int main(int32_t argc, char** argv)
                     if (cmd.trace || doMove || doCrop) {
                         wds = ReadWDS(&buffer[start + HEADER_SIZE]);
 
-                        if (wds.numberOfWindows > 1) {
+                        if (wds.numberOfWindows > 1 && doModification) {
                             std::fprintf(stderr, "Multiple windows at timestamp %s! Please Check!\n", timestampString);
                         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -626,7 +626,7 @@ bool ParseCMD(int32_t argc, char** argv, t_cmd& cmd) {
                 cmd.cutMerge.timeMode = e_cutMergeTimeMode::ms;
             }
             else if (timemode == "frame") {
-                if (remaining < 1) return false;
+                if (remaining < 2) return false;
                 cmd.cutMerge.timeMode = e_cutMergeTimeMode::frame;
                 std::string strFactor = argv[i];
 
@@ -708,7 +708,7 @@ OPTIONS:
 CUT&MERGE OPTIONS:
   --list <list of sections>
   --format (secut | (vapoursynth | vs) | (avisynth | avs) | remap)
-  --timemode (ms | frame | timestamp)
+  --timemode (ms | frame (<num>/<den> | <fps>) | timestamp)
   --fixmode (cut | (delete | del))
 
 Delay and resync command are executed in the order supplied.

--- a/main.cpp
+++ b/main.cpp
@@ -804,6 +804,12 @@ int main(int32_t argc, char** argv)
                     return -1;
                 }
 
+                t_timestamp timestamp = PTStoTimestamp(header.pts1);
+                char timestampString[13]; // max 99:99:99.999
+                std::snprintf(timestampString, 13, "%lu:%02lu:%02lu.%03lu", timestamp.hh, timestamp.mm, timestamp.ss, timestamp.ms);
+                char offsetString[13];    // max 0xFFFFFFFFFF (1TB)
+                std::snprintf(offsetString, 13, "%#zx", start);
+
                 if (doResync) {
                     header.pts1 = (uint32_t)std::round((double)header.pts1 * cmd.resync);
                 }
@@ -817,7 +823,10 @@ int main(int32_t argc, char** argv)
 
                 switch (header.segmentType) {
                 case 0x14:
-                    //std::printf("PDS\r\n");
+                    if (cmd.trace) {
+                        std::printf("  + PDS Segment: offset %s\n", offsetString);
+                        // TODO: Print other fields?
+                    }
                     if (doTonemap) {
                         pds = ReadPDS(&buffer[start + HEADER_SIZE], header.dataLength);
 
@@ -835,13 +844,47 @@ int main(int32_t argc, char** argv)
                     }
                     break;
                 case 0x15:
-                    //std::printf("ODS\r\n");
+                    if (cmd.trace) {
+                        std::printf("  + ODS Segment: offset %s\n", offsetString);
+                        // TODO: Print other fields?
+                    }
                     break;
                 case 0x16:
-                    //std::printf("PCS\r\n");
-                    if (doMove | doCrop || cmd.addZero || cmd.cutMerge.doCutMerge) {
+                    if (cmd.trace) {
+                        std::printf("+ DS\n");
+                        std::printf("  + PTS: %s\n", timestampString);
+                        std::printf("  + PCS Segment: offset %s\n", offsetString);
+                    }
+                    if (cmd.trace || doMove | doCrop || cmd.addZero || cmd.cutMerge.doCutMerge) {
                         pcs = ReadPCS(&buffer[start + HEADER_SIZE]);
                         offsetCurrPCS = start;
+
+                        if (cmd.trace) {
+                            std::printf("    + Video size: %ux%u\n", pcs.width, pcs.height);
+                            std::printf("    + Composition number: %u\n", pcs.compositionNumber);
+                            std::printf("    + Composition state: ");
+                            switch (pcs.compositionState) {
+                                case 0x00: std::printf("Normal\n"); break;
+                                case 0x40: std::printf("Aquisition Point\n"); break;
+                                case 0x80: std::printf("Epoch Start\n"); break;
+                                default:   std::printf("%#x\n", pcs.compositionState); break;
+                            }
+                            if (pcs.paletteUpdFlag == 0x80) {
+                                std::printf("    + Palette update: True\n");
+                                std::printf("    + Palette ID: %u\n", pcs.paletteID);
+                            }
+                            for (int i = 0; i < pcs.numCompositionObject; i++) {
+                                std::printf("    + Composition object\n");
+                                t_compositionObject object = pcs.compositionObject[i];
+                                std::printf("      + Object ID: %u\n", object.objectID);
+                                std::printf("      + Window ID: %u\n", object.windowID);
+                                std::printf("      + Position: %u,%u\n", object.objectHorPos, object.objectVerPos);
+                                if (object.objectCroppedFlag == 0x40) {
+                                    std::printf("      + Object cropped: True\n");
+                                    // TODO: Print crop fields
+                                }
+                            }
+                        }
 
                         if (doCrop) {
                             screenRect.x      = 0 + cmd.crop.left;
@@ -853,14 +896,12 @@ int main(int32_t argc, char** argv)
                             pcs.height = screenRect.height;
 
                             if (pcs.numCompositionObject > 1) {
-                                t_timestamp timestamp = PTStoTimestamp(header.pts1);
-                                std::fprintf(stderr, "Multiple composition object at timestamp %lu:%02lu:%02lu.%03lu! Please Check!\n", timestamp.hh, timestamp.mm, timestamp.ss, timestamp.ms);
+                                std::fprintf(stderr, "Multiple composition object at timestamp %s! Please Check!\n", timestampString);
                             }
 
                             for (int i = 0; i < pcs.numCompositionObject; i++) {
                                 if (pcs.compositionObject[i].objectCroppedFlag == 0x40) {
-                                    t_timestamp timestamp = PTStoTimestamp(header.pts1);
-                                    std::fprintf(stderr, "Object Cropped Flag set at timestamp %lu:%02lu:%02lu.%03lu! Implement it!\n", timestamp.hh, timestamp.mm, timestamp.ss, timestamp.ms);
+                                    std::fprintf(stderr, "Object Cropped Flag set at timestamp %s! Implement it!\n", timestampString);
                                 }
 
                                 if (cmd.crop.left > pcs.compositionObject[i].objectHorPos) {
@@ -940,14 +981,24 @@ int main(int32_t argc, char** argv)
                     }
                     break;
                 case 0x17:
-                    //std::fprintf(stderr, "WDS\r\n");
+                    if (cmd.trace) {
+                        std::printf("  + WDS Segment: offset %s\n", offsetString);
+                    }
                     fixPCS = false;
-                    if (doMove || doCrop) {
+                    if (cmd.trace || doMove || doCrop) {
                         wds = ReadWDS(&buffer[start + HEADER_SIZE]);
 
                         if (wds.numberOfWindows > 1) {
-                            t_timestamp timestamp = PTStoTimestamp(header.pts1);
-                            std::fprintf(stderr, "Multiple windows at timestamp %lu:%02lu:%02lu.%03lu! Please Check!\n", timestamp.hh, timestamp.mm, timestamp.ss, timestamp.ms);
+                            std::fprintf(stderr, "Multiple windows at timestamp %s! Please Check!\n", timestampString);
+                        }
+
+                        if (cmd.trace) {
+                            for (int i = 0; i < wds.numberOfWindows; i++) {
+                                std::printf("    + Window\n");
+                                t_window window = wds.windows[i];
+                                std::printf("      + Window ID: %u\n", window.windowID);
+                                std::printf("      + Window frame: %u,%u,%u,%u\n", window.WindowsHorPos, window.WindowsVerPos, window.WindowsWidth, window.WindowsHeight);
+                            }
                         }
 
                         if (doMove) {
@@ -968,8 +1019,7 @@ int main(int32_t argc, char** argv)
                                     if (object->windowID != window->windowID) continue;
 
                                     if (object->objectCroppedFlag == 0x40) {
-                                        t_timestamp timestamp = PTStoTimestamp(header.pts1);
-                                        std::fprintf(stderr, "Object Cropped Flag set at timestamp %lu:%02lu:%02lu.%03lu! Crop fields are not supported yet.\n", timestamp.hh, timestamp.mm, timestamp.ss, timestamp.ms);
+                                        std::fprintf(stderr, "Object Cropped Flag set at timestamp %s! Crop fields are not supported yet.\n", timestampString);
                                         /*
                                         object->objCropHorPos += clampedDeltaX;
                                         object->objCropVerPos += clampedDeltaY;
@@ -995,8 +1045,7 @@ int main(int32_t argc, char** argv)
 
                                 if (wndRect.width > screenRect.width
                                     || wndRect.height > screenRect.height) {
-                                    t_timestamp timestamp = PTStoTimestamp(header.pts1);
-                                    std::fprintf(stderr, "Window is bigger then new screen area at timestamp %lu:%02lu:%02lu.%03lu\n", timestamp.hh, timestamp.mm, timestamp.ss, timestamp.ms);
+                                    std::fprintf(stderr, "Window is bigger then new screen area at timestamp %s\n", timestampString);
                                     std::fprintf(stderr, "Implement it!\n");
                                     /*
                                     pcs.width = wndRect.width;
@@ -1006,8 +1055,7 @@ int main(int32_t argc, char** argv)
                                 }
                                 else {
                                     if (!rectIsContained(screenRect, wndRect)) {
-                                        t_timestamp timestamp = PTStoTimestamp(header.pts1);
-                                        std::fprintf(stderr, "Window is outside new screen area at timestamp %lu:%02lu:%02lu.%03lu\n", timestamp.hh, timestamp.mm, timestamp.ss, timestamp.ms);
+                                        std::fprintf(stderr, "Window is outside new screen area at timestamp %s\n", timestampString);
 
                                         uint16_t wndRightPoint    = wndRect.x    + wndRect.width;
                                         uint16_t screenRightPoint = screenRect.x + screenRect.width;
@@ -1060,7 +1108,9 @@ int main(int32_t argc, char** argv)
                     }
                     break;
                 case 0x80:
-                    //std:printf("END\r\n");
+                    if (cmd.trace) {
+                        std::printf("  + END Segment: offset %s\n", offsetString);
+                    }
 
                     if (cmd.cutMerge.doCutMerge) {
                         if (cutMerge_foundEnd) {

--- a/main.cpp
+++ b/main.cpp
@@ -851,13 +851,17 @@ int main(int32_t argc, char** argv)
 
                 switch (header.segmentType) {
                 case 0x14:
+                    if (cmd.trace || doTonemap) {
+                        pds = ReadPDS(&buffer[start + HEADER_SIZE], header.dataLength);
+                    }
+
                     if (cmd.trace) {
                         std::printf("  + PDS Segment: offset %s\n", offsetString);
-                        // TODO: Print other fields?
+                        std::printf("    + Palette ID: %u\n", pds.paletteID);
+                        std::printf("    + Version: %u\n", pds.paletteVersionNumber);
+                        std::printf("    + Palette entries: %u\n", pds.paletteNum);
                     }
                     if (doTonemap) {
-                        pds = ReadPDS(&buffer[start + HEADER_SIZE], header.dataLength);
-
                         for (int i = 0; i < pds.paletteNum; i++) {
                             //convert Y from TV level (16-235) to full range
                             double expandedY   = ((((double)pds.palette[i].paletteY - 16.0) * (255.0 / (235.0 - 16.0))) / 255.0);

--- a/main.cpp
+++ b/main.cpp
@@ -546,7 +546,7 @@ bool ParseCMD(int32_t argc, char** argv, t_cmd& cmd) {
         int remaining = argc - i;
         bool recognizedOption = true;
 
-        if (arg == "--trace") {
+        if (arg == "trace" || arg == "--trace") {
             cmd.trace = true;
         }
         else if (arg == "delay" || arg == "--delay") {

--- a/main.cpp
+++ b/main.cpp
@@ -512,14 +512,6 @@ bool parseCutMerge(t_cutMerge* cutMerge) {
 }
 
 bool ParseCMD(int32_t argc, char** argv, t_cmd& cmd) {
-    cmd.trace = false;
-    cmd.delay = 0;
-    cmd.move = {};
-    cmd.crop = {};
-    cmd.resync = 1;
-    cmd.addZero = false;
-    cmd.tonemap = 1;
-
     int i = 1;
 
     cmd.inputFile = argv[i++];


### PR DESCRIPTION
See discussion: https://github.com/MonoS/SupMover/pull/17#issuecomment-1924849735

* Adds a new `--trace` option for printing structure and contents of segments
* Makes positional output file argument optional for actions that don't modify the input (like `--trace`)
* Replaces SEGFAULTs with standard parsing error when user inputs too few arguments
* Inline increment of argument index during parsing to reduce code clutter
* Removes case-insensitivity of options