### PR TITLE
Don't close output when it is null

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -646,7 +646,9 @@ int main(int32_t argc, char** argv)
     }
 
     std::fclose(input);
-    std::fclose(output);
+    if (output != nullptr) {
+        std::fclose(output);
+    }
 
     return 0;
 }


### PR DESCRIPTION
When using `--trace`, `output` is `null` and a call to `std::fclose` results in a segmentation fault (at least on my system). This patch should avoid that `std::flose` call, when it is not required.