### PR TITLE
Adds symmetrical movement sub-flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usage:  SupMover <input.sup> [<output.sup>] [OPTIONS ...]
 OPTIONS:
   --trace
   --delay <ms>
-  --move <delta x> <delta y>
+  --move <delta x> <delta y> <optional -s>
   --crop <left> <top> <right> <bottom>
   --resync (<num>/<den> | <multFactor>)
   --add_zero
@@ -32,6 +32,7 @@ CUT&MERGE OPTIONS:
 * `--move`
   * Shift the windows position of all subpic by the inputed parameters (the image data is left untouched).
   * Position is clamped to the screen edges so that windows are always fully contained within the screen area.
+  * The Sub-flag "-s" allows for symmetrically moving subtitles. For example, `--move 0 5 -s` will move all subtitles below the halfway point of the screen down, and those above the halfway point will be shifted up. 
 * `--crop`
   * Crop the windows area of all subpic by the inputed parameters.
   * This is done losslessly by only shifting the windows position (the image data is left untouched).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Usage:  SupMover <input.sup> [<output.sup>] [OPTIONS ...]
 OPTIONS:
   --trace
   --delay <ms>
-  --move <delta x> <delta y> <optional -s>
+  --move <delta x> <delta y>
+  --symmetrical
   --crop <left> <top> <right> <bottom>
   --resync (<num>/<den> | <multFactor>)
   --add_zero
@@ -32,7 +33,9 @@ CUT&MERGE OPTIONS:
 * `--move`
   * Shift the windows position of all subpic by the inputed parameters (the image data is left untouched).
   * Position is clamped to the screen edges so that windows are always fully contained within the screen area.
-  * The Sub-flag "-s" allows for symmetrically moving subtitles. For example, `--move 0 5 -s` will move all subtitles below the halfway point of the screen down, and those above the halfway point will be shifted up. 
+* `--symmetrical`
+  * For the upper half of the video frame, this reverses vertical movement offsets (for the `--move` command described above). Similarly, this also reverses horizontal movement offsets for the left half of the video frame. This affects both vertical and horizontal at the same time, so if symmetrical movement is only desired on  one axis, you must execute supmover twice.
+  * For example, `--symmetrical --move 0 15` will move all subtitles in the lower half down, and the upper half will be moved upwards, but they will not be moved sideways. `--move -20 0 --symmetrical` will result in all subtitles on the right half of the screen moving inwards in a left direction, and all subtitles on the left will move inwards in a right direction, without affecting their vertical positioning. 
 * `--crop`
   * Crop the windows area of all subpic by the inputed parameters.
   * This is done losslessly by only shifting the windows position (the image data is left untouched).

--- a/cmd.hpp
+++ b/cmd.hpp
@@ -10,7 +10,7 @@ struct t_timestamp {
 struct t_move {
     int16_t deltaX;
     int16_t deltaY;
-    bool symmetrical;
+    bool symmetrical = false; //setting false by default as a safety thing
 };
 
 struct t_crop {
@@ -246,11 +246,10 @@ bool parseCMD(int32_t argc, char** argv, t_cmd& cmd) {
             if (remaining < 2) return false;
             cmd.move.deltaX = atoi(argv[i++]);
             cmd.move.deltaY = atoi(argv[i++]);
-            cmd.move.symmetrical = false;
-            if (remaining >= 3 && std::string(argv[i]) == "-s") {
-                cmd.move.symmetrical = true;
-                i++;
-            }
+        }
+        else if (arg == "symmetrical" || arg == "--symmetrical") {
+            cmd.move.symmetrical = true;
+            i++;
         }
         else if (arg == "crop" || arg == "--crop") {
             if (remaining < 4) return false;

--- a/cmd.hpp
+++ b/cmd.hpp
@@ -245,6 +245,11 @@ bool parseCMD(int32_t argc, char** argv, t_cmd& cmd) {
             if (remaining < 2) return false;
             cmd.move.deltaX = atoi(argv[i++]);
             cmd.move.deltaY = atoi(argv[i++]);
+            cmd.move.symmetrical = false;
+            if (remaining >= 3 && std::string(argv[i]) == "-s") {
+                cmd.move.symmetrical = true;
+                i++;
+            }
         }
         else if (arg == "crop" || arg == "--crop") {
             if (remaining < 4) return false;

--- a/cmd.hpp
+++ b/cmd.hpp
@@ -10,6 +10,7 @@ struct t_timestamp {
 struct t_move {
     int16_t deltaX;
     int16_t deltaY;
+    bool symmetrical;
 };
 
 struct t_crop {

--- a/main.cpp
+++ b/main.cpp
@@ -83,7 +83,7 @@ Usage:  SupMover <input.sup> [<output.sup>] [OPTIONS ...]
 OPTIONS:
   --trace
   --delay <ms>
-  --move <delta x> <delta y>
+  --move <delta x> <delta y> <optional -s>
   --crop <left> <top> <right> <bottom>
   --resync (<num>/<den> | <multFactor>)
   --add_zero
@@ -435,15 +435,33 @@ int main(int32_t argc, char** argv)
                         }
 
                         if (doMove) {
+                            const int16_t videoCenterX = pcs.width / 2; //setup halfway points for optional symmetry flag.
+                            const int16_t videoCenterY = pcs.height / 2; //maybe move inside if statement somewhere?
                             for (int i = 0; i < wds.numberOfWindows; i++) {
                                 t_window *window = &wds.windows[i];
+
+                                const int16_t windowCenterX = window->horizontalPosition + (window->width / 2); //get the coords for the center of the subtitle window
+                                const int16_t windowCenterY = window->verticalPosition + (window->height / 2);
+                                const bool isBesideHalfway = (windowCenterX < videoCenterX); //check if center of subtitle window is past the halfway mark for the video
+                                const bool isAboveHalfway = (windowCenterY < videoCenterY);
+                                int16_t effectiveDeltaX = cmd.move.deltaX; //pass desired move amount to variable for potential editing.
+                                int16_t effectiveDeltaY = cmd.move.deltaY;
+                                //todo: more elegant way of doing this? maybe some way of quitting early for movement values of 0
+                                //better way than this or nested if-statements?
+                                if (isBesideHalfway && cmd.move.symmetrical) { 
+                                    effectiveDeltaX = -effectiveDeltaX;
+                                }
+                                if (isAboveHalfway && cmd.move.symmetrical) {
+                                    effectiveDeltaY = -effectiveDeltaY;
+                                }
+                                
                                 int16_t minDeltaX = -(int16_t)window->horizontalPosition;
                                 int16_t minDeltaY = -(int16_t)window->verticalPosition;
                                 int16_t maxDeltaX = pcs.width - (window->horizontalPosition + window->width);
                                 int16_t maxDeltaY = pcs.height - (window->verticalPosition + window->height);
-                                int16_t clampedDeltaX = std::min(std::max(cmd.move.deltaX, minDeltaX), maxDeltaX);
-                                int16_t clampedDeltaY = std::min(std::max(cmd.move.deltaY, minDeltaY), maxDeltaY);
-
+                                int16_t clampedDeltaX = std::min(std::max(effectiveDeltaX, minDeltaX), maxDeltaX);
+                                int16_t clampedDeltaY = std::min(std::max(effectiveDeltaY, minDeltaY), maxDeltaY);
+                                
                                 window->horizontalPosition += clampedDeltaX;
                                 window->verticalPosition += clampedDeltaY;
 

--- a/main.cpp
+++ b/main.cpp
@@ -83,7 +83,8 @@ Usage:  SupMover <input.sup> [<output.sup>] [OPTIONS ...]
 OPTIONS:
   --trace
   --delay <ms>
-  --move <delta x> <delta y> <optional -s>
+  --move <delta x> <delta y>
+  --symmetrical
   --crop <left> <top> <right> <bottom>
   --resync (<num>/<den> | <multFactor>)
   --add_zero


### PR DESCRIPTION
Please review this, I'm not a very competent coder.

This sub-flag `-s` for the movement command reverses the movement direction of subtitles if they're above the midway point on the screen, like such:

<img width="1795" height="1005" alt="image" src="https://github.com/user-attachments/assets/1ccb4e45-1fe5-4c30-9637-eac81ce915a4" />

closes #37