### PR TITLE
Fixes incremental bug with symmetrical flag.

### DIFF
--- a/cmd.hpp
+++ b/cmd.hpp
@@ -279,7 +279,6 @@ bool parseCMD(int32_t argc, char** argv, t_cmd& cmd) {
         }
         else if (arg == "symmetrical" || arg == "--symmetrical") {
             cmd.move.symmetrical = true;
-            i++;
         }
         else if (arg == "crop" || arg == "--crop") {
             if (remaining < 4) return false;


### PR DESCRIPTION
Due to sheer incompetence on my part, I added an erroneous i++ to the code parsing the symmetrical flag.

This causes the next argument to be skipped, which can be problematic.

As a temporary workaround, if you're using the --symmetrical argument, I advise adding it to the end of your arguments. (You could theoretically add a dummy argument following --symmetrical, but that might also lead to unintended behavior if you execute supmover with that same command after this has been fixed. 